### PR TITLE
🐛 [BUGFIX] - Slides href in Publications overview

### DIFF
--- a/publications.md
+++ b/publications.md
@@ -25,7 +25,7 @@ title: Publications
       {%- if publication.full-text %} [Full-text]({{publication.full-text}}).{% endif %}
       <!-- {%- if publication.bibtex %} <a class="clipboard" data-clipboard-text="{{publication.bibtex}}">Copy bibtex</a>.{% endif %} -->
       {%- if publication.slides %}
-      [Slides]({{publication.slides}}.)
+      [Slides]({{publication.slides}}).
     {% endif -%}
   {%- if publication.video %}
     [<ion-icon name="logo-youtube"></ion-icon>]({{publication.video}})


### PR DESCRIPTION
## Description
Some of the 'Slides' hyperlinks in the Publications overview include a dot at the end and hence do not work (link suffix is _.pdf._ instead of _.pdf_). The intended behaviour is most likely the dot behind the word 'Slides' and not the hyperlink. This pull-request does exactly that: fix the href links and render a dot after the word 'Slides'.

## Reproduction

1. Go to 'https://luiscruz.github.io/publications'
2. Click any 'Slides' hyperlink in the overview (note: no '.' (dot) after the word 'Slides')
3. 404 Error of the respective link

## Screenshots
Dot is missing after 'Slides'
![image](https://user-images.githubusercontent.com/56686692/231426666-3e025408-4c11-4976-8867-818d665520bd.png)

Hyperlink with dot appended, results in 404s
![image](https://user-images.githubusercontent.com/56686692/231427051-8e9624ee-7671-4c51-a7ea-1967068894d4.png)

