### PR TITLE
Fix formatting mistake ("textnormal" instead of "text" command)

### DIFF
--- a/_posts/2023-05-13-energy-units.md
+++ b/_posts/2023-05-13-energy-units.md
@@ -38,7 +38,7 @@ Another common unit is kilowatt-hour (kWh). For example, it is used to report ho
 
 $$ 1\text{kWh} = 3,600,000\text{J}$$
 
-For example, saying that 1 bitcoin transaction requires more than 6 giga-joules ($6 \cdot 10^9 \textnormal{J}$) is similar to saying that it requires more than 1667kWh (approximately).
+For example, saying that 1 bitcoin transaction requires more than 6 giga-joules ($6 \cdot 10^9 \text{J}$) is similar to saying that it requires more than 1667kWh (approximately).
 
 ## Power
 


### PR DESCRIPTION
Upon checking the merged [energy units article](https://luiscruz.github.io/2023/05/13/energy-units.html), I noticed a formatting mistake that also shows in the front-end:

![formatting mistake](https://github.com/luiscruz/luiscruz.github.io/assets/56686692/0b747b9d-620f-4126-a967-7f59ba12e96d)

Instead of `\textnormal`, it needs to be `\text`. This is fixed now. My apologies!